### PR TITLE
Visual update

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -93,6 +93,7 @@ An array of dataset definitions (objects) with the following layout
 
  - `id`: The ID of the dataset. This is used in events and callbacks
  - `color`: The color to display the dataset. Anything possible for CSS works here
+ - `noBorder`: Boolean option to disable darker record/bucket color. if border of records/buckets should have the border color same as `color` (border not visible) or darker.
  - `lineplot`: Whether this dataset will be displayed as a line
  - `histogramThreshold`: Sets the threshold, when this dataset will be displayed
    in a quantized manner.

--- a/Readme.md
+++ b/Readme.md
@@ -98,7 +98,7 @@ An array of dataset definitions (objects) with the following layout
 
  - `id`: The ID of the dataset. This is used in events and callbacks
  - `color`: The color to display the dataset. Anything possible for CSS works here
- - `noBorder`: Boolean option to disable darker record/bucket color. if border of records/buckets should have the border color same as `color` (border not visible) or darker.
+ - `noBorder`: Boolean option to disable individual record/bucket borders.
  - `lineplot`: Whether this dataset will be displayed as a line
  - `histogramThreshold`: Sets the threshold, when this dataset will be displayed
    in a quantized manner.

--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,11 @@ It is passed the bin - an array of records (again an array of [start, end,
 params]). By default, the `tooltipFormatter` is invoked for each record and
 joined by a `<br>`.
 
+### `alternativeBrush` - `boolean`
+
+When set to `true`, the selection brush is displayed below other parts of timeslider and looks like a thin strip with circle handles on sides.
+Defaults to `false`.
+
 ### `constrain` - `boolean`
 
 When set, the viewable interval is constrained to the `domain`.

--- a/src/d3.timeslider.coffee
+++ b/src/d3.timeslider.coffee
@@ -242,17 +242,15 @@ class TimeSlider extends EventEmitter
             @gBrush.selectAll('rect')
                 .attr('height', 6)
                 .attr('y', "#{@options.height + 6}")
-            @handleShape = d3.svg.arc()
-                .innerRadius(0)
-                .outerRadius(8)
-                .startAngle(0)
-                .endAngle(2 * Math.PI)
-            @gBrush.selectAll('.resize').append('path')
+
+            @gBrush.selectAll('.resize').append('circle')
                 .attr('class', 'handle-circle')
                 .attr('fill', '#000000')
                 .attr('cursor', 'ew-resize')
-                .attr('transform', "translate(0, #{@options.height + 9})")
-                .attr('d', @handleShape)
+                .attr('r', 8)
+                .attr('cx', 0)
+                .attr('cy', @options.height + 9)
+
         if @brushTooltip
             # setup hover events on brush
             @gBrush.selectAll('.resize.w')

--- a/src/d3.timeslider.coffee
+++ b/src/d3.timeslider.coffee
@@ -641,6 +641,7 @@ class TimeSlider extends EventEmitter
             id: id,
             index: index,
             color: definition.color,
+            noBorder: definition.noBorder,
             highlightFillColor: definition.highlightFillColor,
             highlightStrokeColor: definition.highlightStrokeColor,
             source: definition.source,

--- a/src/d3.timeslider.coffee
+++ b/src/d3.timeslider.coffee
@@ -64,6 +64,9 @@ class TimeSlider extends EventEmitter
         else
             @options.width = @svg[0][0].clientWidth
             @options.height = @svg[0][0].clientHeight
+        # offset whole timeslider to make space below for the brush
+        if @options.alternativeBrush
+            @options.height = @options.height - 18
 
         ### END-TODO ###
 
@@ -225,12 +228,53 @@ class TimeSlider extends EventEmitter
                 .attr('y', 0)
 
         # add a group to draw the brush in
-        @svg.append('g')
+        @gBrush = @svg.append('g')
             .attr('class', 'brush')
             .call(@brush)
-            .selectAll('rect')
-                .attr('height', "#{@options.height - 19}")
+
+        if !@options.alternativeBrush
+            # traditional view with box for selection
+            @gBrush.selectAll('rect')
+                .attr('height', '#{@options.height - 19}')
                 .attr('y', 0)
+        else
+        # alternative brush
+            @gBrush.selectAll('rect')
+                .attr('height', 6)
+                .attr('y', "#{@options.height + 6}")
+            @handleShape = d3.svg.arc()
+                .innerRadius(0)
+                .outerRadius(8)
+                .startAngle(0)
+                .endAngle(2 * Math.PI)
+            @gBrush.selectAll('.resize').append('path')
+                .attr('class', 'handle-circle')
+                .attr('fill', '#000000')
+                .attr('cursor', 'ew-resize')
+                .attr('transform', "translate(0, #{@options.height + 9})")
+                .attr('d', @handleShape)
+        if @brushTooltip
+            # setup hover events on brush
+            @gBrush.selectAll('.resize.w')
+                .on('mouseover', => 
+                    @tooltipBrushMin.transition()
+                        .duration(100)
+                        .style('opacity', 0.9))
+                .on('mouseout', => 
+                    if !@brushing
+                        @tooltipBrushMin.transition()
+                            .duration(100)
+                            .style('opacity', 0))
+            @gBrush.selectAll('.resize.e')
+                .on('mouseover', => 
+                    @tooltipBrushMax.transition()
+                        .duration(100)
+                        .style('opacity', 0.9))
+                .on('mouseout', => 
+                    if !@brushing
+                        @tooltipBrushMax.transition()
+                            .duration(100)
+                            .style('opacity', 0))
 
         # add a group that contains all datasets
         @svg.append('g')

--- a/src/d3.timeslider.coffee
+++ b/src/d3.timeslider.coffee
@@ -235,7 +235,7 @@ class TimeSlider extends EventEmitter
         if !@options.alternativeBrush
             # traditional view with box for selection
             @gBrush.selectAll('rect')
-                .attr('height', '#{@options.height - 19}')
+                .attr('height', "#{@options.height - 19}")
                 .attr('y', 0)
         else
         # alternative brush

--- a/src/d3.timeslider.less
+++ b/src/d3.timeslider.less
@@ -50,7 +50,7 @@ svg.timeslider {
   }
 
   .brush {
-    .extent {
+    .extent, .handle-circle {
       opacity: .9;
       stroke: #333;
     }

--- a/src/datasets/bucket-dataset.coffee
+++ b/src/datasets/bucket-dataset.coffee
@@ -159,6 +159,7 @@ class BucketDataset extends RecordDataset
                 "translate(#{ scales.x(d[0]) }, #{ -y(d[2]) or 0 })"
                 )
             .attr('height', (d) -> if d[2] then y(d[2]) else 0)
+            .attr('stroke-width', if @noBorder then 2 else 1)
 
         bucketElement
             .on('mouseover', (bucket) =>

--- a/src/datasets/bucket-dataset.coffee
+++ b/src/datasets/bucket-dataset.coffee
@@ -145,6 +145,8 @@ class BucketDataset extends RecordDataset
                 , false)
                 if highlight
                     @highlightStrokeColor
+                else if @noBorder
+                    d3.rgb(@color)
                 else
                     d3.rgb(@color).darker()
             )

--- a/src/datasets/dataset.coffee
+++ b/src/datasets/dataset.coffee
@@ -4,7 +4,7 @@ EventEmitter = require '../event-emitter.coffee'
 
 # Dataset utility class for internal use only
 class Dataset extends EventEmitter
-    constructor: ({ @id,  @color, @highlightFillColor, @highlightStrokeColor,
+    constructor: ({ @id,  @color, @noBorder, @highlightFillColor, @highlightStrokeColor,
                     @source, @sourceParams, @index, @records,
                     @paths, @lineplot, @ordinal, @element, debounceTime }) ->
         @fetchDebounced = debounce(@doFetch, debounceTime)

--- a/src/datasets/record-dataset.coffee
+++ b/src/datasets/record-dataset.coffee
@@ -108,7 +108,7 @@ class RecordDataset extends Dataset
 
     drawRanges: (records, scales, options, highlight = false) ->
         color = if highlight then @highlightFillColor else @color
-        strokeColor = if highlight then @highlightStrokeColor else d3.rgb(color).darker()
+        strokeColor = if highlight then @highlightStrokeColor else if @noBorder then d3.rgb(color) else  d3.rgb(color).darker()
         className = if highlight then 'highlight-record' else 'record'
         { ticksize, recordFilter } = options
         rect = (elem) =>
@@ -142,7 +142,7 @@ class RecordDataset extends Dataset
 
     drawPoints: (records, scales, options, highlight = false) ->
         color = if highlight then @highlightFillColor else @color
-        strokeColor = if highlight then @highlightStrokeColor else d3.rgb(color).darker()
+        strokeColor = if highlight then @highlightStrokeColor else if @noBorder then d3.rgb(color) else d3.rgb(color).darker()
         className = if highlight then 'highlight-record' else 'record'
         { ticksize, recordFilter } = options
         circle = (elem) =>
@@ -337,6 +337,8 @@ class RecordDataset extends Dataset
                 , false)
                 if highlight
                     @highlightStrokeColor
+                else if @noBorder
+                    d3.rgb(@color)
                 else
                     d3.rgb(@color).darker()
             )


### PR DESCRIPTION
- added per-dataset noBorder config option, which toggles use of same stroke color as fill color (no darker border) and sets stroke-width to 2
- added  TimeSlider alternativeTimeslider config option, which displays selection brush below timeslider with circle handles for dragging
- added onHover tooltips to min/max respectively