### PR TITLE
Improve on buckets performance in edge cases 

### DIFF
--- a/src/d3.timeslider.coffee
+++ b/src/d3.timeslider.coffee
@@ -427,6 +427,7 @@ class TimeSlider extends EventEmitter
                 .attr("id", "reload")
                 .attr("class", "control")
                 .on("click", ()=>
+                    @dispatch('reload')
                     for dataset of @datasets
                         @reloadDataset(dataset, true)
                 )

--- a/src/datasets/bucket-dataset.coffee
+++ b/src/datasets/bucket-dataset.coffee
@@ -35,10 +35,7 @@ class BucketDataset extends RecordDataset
     doFetch: (start, end, params) ->
         { scales } = params
         [ ticks, resolution ] = @makeTicks(scales.x)
-        if @useBuckets(start, end)
-            @doFetchBuckets(start, end, resolution, ticks, params)
-        else
-            super(start, end, params)
+        @doFetchBuckets(start, end, resolution, ticks, params)
 
     doFetchBuckets: (start, end, resolution, ticks, params) ->
         source = @getSourceFunction(@bucketSource)
@@ -55,7 +52,7 @@ class BucketDataset extends RecordDataset
             summaryCallback = after(bucketsToFetch.length, () =>
                 # after all buckets fetched and count > 0 but below threshold
                 # fetch individual records for start,end timeframe
-                if not @bucketCache.isCountLower(start, end, 1) and not @useBuckets(start, end)
+                if not @bucketCache.isCountLower(start, end, 1)[0] and not @useBuckets(start, end)
                     RecordDataset.prototype.doFetch.call(this, start, end, params)
             )
 

--- a/src/datasets/bucket-dataset.coffee
+++ b/src/datasets/bucket-dataset.coffee
@@ -7,12 +7,10 @@ class BucketDataset extends RecordDataset
         super(options)
         @bucketCache = new BucketCache()
         { @bucketSource } = options
-        currentBucketSyncState = 0
-        lastBucketSyncState = 0
         @toFetch = 0
 
     useBuckets: (start, end, preferRecords = false) ->
-        [ isLower, definite ] = @bucketCache.isCountLower(start, end, @histogramThreshold, preferRecords)
+        [ isLower, definite ] = @bucketCache.isCountLower(start, end, @histogramThreshold)
 
         if preferRecords and not definite
             count = @cache.get(start, end).length
@@ -37,9 +35,6 @@ class BucketDataset extends RecordDataset
     doFetch: (start, end, params) ->
         { scales } = params
         [ ticks, resolution ] = @makeTicks(scales.x)
-
-        [ isLower, definite ] = @bucketCache.isCountLower(start, end, @histogramThreshold)
-
         if @useBuckets(start, end)
             @doFetchBuckets(start, end, resolution, ticks, params)
         else

--- a/src/datasets/bucket-dataset.coffee
+++ b/src/datasets/bucket-dataset.coffee
@@ -52,9 +52,10 @@ class BucketDataset extends RecordDataset
         if bucketsToFetch.length > 0
             @toFetch += bucketsToFetch.length
             @listeners.syncing()
-
             summaryCallback = after(bucketsToFetch.length, () =>
-                if not @useBuckets(start, end)
+                # after all buckets fetched and count > 0 but below threshold
+                # fetch individual records for start,end timeframe
+                if not @bucketCache.isCountLower(start, end, 1) and not @useBuckets(start, end)
                     RecordDataset.prototype.doFetch.call(this, start, end, params)
             )
 


### PR DESCRIPTION
- fetches bucket count always and only fetches individual records if total count in current <start/end> < `histogramThreshold` but larger than 0